### PR TITLE
fix: use localeCompare in sortEntitiesByName

### DIFF
--- a/src/functions/functionsThatDontUseSettings.ts
+++ b/src/functions/functionsThatDontUseSettings.ts
@@ -9,7 +9,7 @@ export const sortEntitiesByName = <T extends NameHaver>(ents: T[]) => {
   return ents.sort((a, b) => {
     const aName = a.name || "";
     const bName = b.name || "";
-    return aName < bName ? -1 : aName > bName ? 1 : 0;
+    return aName.localeCompare(bName);
   });
 };
 


### PR DESCRIPTION
Hi! First, thank you for this system! 😄 

When abilities contains accented characters, the order is wrong ; for example:
* Déguisement
* Explosifs
* Filature
* Électricité

instead of 
* Déguisement
* Électricité
* Explosifs
* Filature

Using [`a.localeCompare(b)`](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare) allows to fix this bad behaviour.