### PR TITLE
Revert "fix: use localeCompare in sortEntitiesByName"

### DIFF
--- a/src/functions/functionsThatDontUseSettings.ts
+++ b/src/functions/functionsThatDontUseSettings.ts
@@ -9,7 +9,7 @@ export const sortEntitiesByName = <T extends NameHaver>(ents: T[]) => {
   return ents.sort((a, b) => {
     const aName = a.name || "";
     const bName = b.name || "";
-    return aName.localeCompare(bName);
+    return aName < bName ? -1 : aName > bName ? 1 : 0;
   });
 };
 


### PR DESCRIPTION
Reverts n3dst4/gumshoe-fvtt#204  - this should be targetted onto `main`